### PR TITLE
feat(db): записать url к бд, в более надежном виде

### DIFF
--- a/.env
+++ b/.env
@@ -1,9 +1,10 @@
 # Postgres
 POSTGRES_SERVER=db
+POSTGRES_HOST=localhost
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=kopkop99
 POSTGRES_DB=app-db
-DATABASE=postgres
+DATABASE=postgresql
 
 # PgAdmin
 PGADMIN_LISTEN_PORT=5050

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,14 +1,14 @@
+import os
 import sys
 from logging.config import fileConfig
 
+from alembic import context
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
-
-from alembic import context
+from sqlalchemy.engine import URL
 
 sys.path = ['', '..'] + sys.path[1:]
 
-from app.db.session import SQLALCHEMY_DATABASE_URL
 from app.db.base import Base
 
 # this is the Alembic Config object, which provides
@@ -25,7 +25,6 @@ if config.config_file_name is not None:
 # from myapp import mymodel
 target_metadata = Base.metadata
 
-
 # target_metadata = None
 
 
@@ -33,6 +32,15 @@ target_metadata = Base.metadata
 # can be acquired:
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
+
+
+url_object = URL.create(
+    os.getenv('DATABASE', 'postgresql'),
+    username=os.getenv('POSTGRES_USER', 'postgres'),
+    password=os.getenv('POSTGRES_PASSWORD', ''),
+    host=os.getenv('POSTGRES_HOST', 'localhost'),
+    database=os.getenv('POSTGRES_DB', 'app-db'),
+)
 
 
 def run_migrations_offline() -> None:
@@ -47,13 +55,10 @@ def run_migrations_offline() -> None:
     script output.
 
     """
-    # url = config.get_main_option("sqlalchemy.url")
-    url = config.get_main_option(SQLALCHEMY_DATABASE_URL)
+    url = url_object
     context.configure(
         url=url,
         target_metadata=target_metadata,
-        render_as_batch=True,
-        # TODO добавил сам смотря тут https://stackoverflow.com/questions/30378233/sqlite-lack-of-alter-support-alembic-migration-failing-because-of-this-solutio
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
     )
@@ -70,7 +75,7 @@ def run_migrations_online() -> None:
 
     """
     configuration = config.get_section(config.config_ini_section)
-    configuration['sqlalchemy.url'] = SQLALCHEMY_DATABASE_URL
+    configuration['sqlalchemy.url'] = url_object
     connectable = engine_from_config(
         configuration,
         prefix="sqlalchemy.",

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -3,27 +3,17 @@ from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
-# url_object = URL.create(
-#     'postgresql',
-#     username='postgres',
-#     password='kopkop99',
-#     host='localhost',
-#     # port=5432,
-#     database='app',
-# )
+url_object = URL.create(
+    'postgresql',
+    username='postgres',
+    password='kopkop99',
+    host='localhost',
+    database='app-db',
+)
 
-SQLALCHEMY_DATABASE_URL = "postgresql://postgres:kopkop99@localhost/app-db"
-
-# SQLALCHEMY_DATABASE_URL = "sqlite:///C:/Users/MaxDroN/python_projects/const_data_books/readings_.db"
-
-# engine = create_engine(
-#     SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
-# )
-
-engine = create_engine(SQLALCHEMY_DATABASE_URL)
+engine = create_engine(url_object)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()
-
 
 Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
В alembic/env.py данные о url берутся из виртуального окружения (файл .env). Теперь нужно запускать alembic так:
pipenv run alembic revision --autogenerate -m "test_name" а после так:
pipenv run alembic upgrade head

В db/session планируется не считывать данные о url напрямую, а брать их из настроек.

Так же убрать один аргумент из context.configure(), без него не работало с sqlite, но сейчас с postgres работает и без этого аргумента.