### PR TITLE
feat(models): добавить аннотации с указанием None в Mapped в поля rel…

### DIFF
--- a/app/models/bible_book/bible_book.py
+++ b/app/models/bible_book/bible_book.py
@@ -1,8 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import sqlalchemy as sa
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from app import enums
 from app.db.session import Base
+
+if TYPE_CHECKING:
+    from app.schemas.bible_book.zachalo import Zachalo
 
 
 class BibleBook(Base):
@@ -19,4 +26,4 @@ class BibleBook(Base):
     abbr: Mapped[enums.BibleBookAbbr] = mapped_column(unique=True)
     abbr_ru: Mapped[enums.BibleBookAbbrRu] = mapped_column(unique=True)
 
-    zachalos: Mapped[list['Zachalo']] = relationship(back_populates='bible_book')
+    zachalos: Mapped[list[Zachalo]] = relationship(back_populates='bible_book')

--- a/app/models/bible_book/zachalo.py
+++ b/app/models/bible_book/zachalo.py
@@ -1,7 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import sqlalchemy as sa
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from app.db.session import Base
+
+if TYPE_CHECKING:
+    from app.schemas.reading import Reading
+    from app.schemas.bible_book.bible_book import BibleBook
 
 
 class Zachalo(Base):
@@ -11,8 +19,8 @@ class Zachalo(Base):
     num: Mapped[int] = mapped_column(sa.SmallInteger)
     title: Mapped[str | None] = mapped_column(sa.String(30), unique=True)
 
-    bible_book_id = mapped_column(sa.ForeignKey('bible_books.id'))
+    bible_book_id: Mapped[int] = mapped_column(sa.ForeignKey('bible_books.id'))
 
-    bible_book: Mapped['BibleBook'] = relationship(back_populates='zachalos')
+    bible_book: Mapped[BibleBook] = relationship(back_populates='zachalos')
 
-    readings: Mapped[list['Reading']] = relationship(back_populates='zachalo')
+    readings: Mapped[list[Reading]] = relationship(back_populates='zachalo')

--- a/app/models/book/book.py
+++ b/app/models/book/book.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import sqlalchemy as sa
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from app.db.session import Base
+
+if TYPE_CHECKING:
+    from app.models.book.saint_live import SaintLive
 
 
 class Book(Base):
@@ -10,4 +17,4 @@ class Book(Base):
 
     title: Mapped[str] = mapped_column(sa.String(100), unique=True)
 
-    saint_live: Mapped['SaintLive'] = relationship(back_populates='book', uselist=False)
+    saint_live: Mapped[SaintLive | None] = relationship(back_populates='book')

--- a/app/models/book/saint_live.py
+++ b/app/models/book/saint_live.py
@@ -1,16 +1,23 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import sqlalchemy as sa
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from app.db.session import Base
 
+if TYPE_CHECKING:
+    from app.models.book.book import Book
+
 
 class SaintLive(Base):
     __tablename__ = 'saints_lives'
 
-    book_id = mapped_column(sa.ForeignKey('books.id'), primary_key=True)
+    book_id: Mapped[int] = mapped_column(sa.ForeignKey('books.id'), primary_key=True)
 
     # book = relationship('Book', backref=backref('saint_live', uselist=False))
-    book: Mapped['Book'] = relationship(back_populates='saint_live')
+    book: Mapped[Book] = relationship(back_populates='saint_live')
 
-    # saint_id = Column(Integer, ForeignKey('saints.id'))
+    # saint_id: Mapped[int | None] = Column(Integer, ForeignKey('saints.id'))
     # saint = relationship('Saint', back_populates='saints_lives')

--- a/app/models/date.py
+++ b/app/models/date.py
@@ -1,7 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import sqlalchemy as sa
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from app.db.session import Base
+
+if TYPE_CHECKING:
+    from app.models.day import Day
+    from app.models.movable_date.movable_day import MovableDay
 
 
 class Date(Base):
@@ -12,5 +20,5 @@ class Date(Base):
 
     _offset_year: Mapped[int] = mapped_column(sa.SmallInteger)
 
-    day: Mapped['Day'] = relationship(back_populates='movable_days')
-    movable_day: Mapped['MovableDay'] = relationship(back_populates='days')
+    day: Mapped[Day] = relationship(back_populates='movable_days')
+    movable_day: Mapped[MovableDay] = relationship(back_populates='days')

--- a/app/models/day.py
+++ b/app/models/day.py
@@ -1,7 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import sqlalchemy as sa
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from app.db.session import Base
+
+if TYPE_CHECKING:
+    from app.models.holiday.holiday import Holiday
+    from app.models.date import Date
 
 
 class Day(Base):
@@ -11,6 +19,6 @@ class Day(Base):
     month: Mapped[int] = mapped_column(sa.SmallInteger)
     day: Mapped[int] = mapped_column(sa.SmallInteger)
 
-    holidays: Mapped[list['Holiday']] = relationship(back_populates='day')
+    holidays: Mapped[list[Holiday]] = relationship(back_populates='day')
 
-    movable_days: Mapped[list['Date']] = relationship(back_populates='day')
+    movable_days: Mapped[list[Date]] = relationship(back_populates='day')

--- a/app/models/holiday/holiday.py
+++ b/app/models/holiday/holiday.py
@@ -1,7 +1,18 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import sqlalchemy as sa
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from app.db.session import Base
+
+if TYPE_CHECKING:
+    from app.models.day import Day
+    from app.models.holiday.holiday_category import HolidayCategory
+    from app.models.movable_date.movable_day import MovableDay
+    from app.models.saint.saint import Saint, SaintsHolidays
+    from app.models.year import Year
 
 
 class Holiday(Base):
@@ -11,19 +22,19 @@ class Holiday(Base):
     title: Mapped[str | None] = mapped_column(sa.String(100), unique=True)
     slug: Mapped[str] = mapped_column(sa.String(70), unique=True)
 
-    holiday_category_id = mapped_column(sa.ForeignKey('holidays_categories.id'))
-    year_id = mapped_column(sa.ForeignKey('years.id'))
-    day_id = mapped_column(sa.ForeignKey('days.id'))
-    movable_day_id = mapped_column(sa.ForeignKey('movable_days.id'))
+    holiday_category_id: Mapped[int] = mapped_column(sa.ForeignKey('holidays_categories.id'))
+    year_id: Mapped[int | None] = mapped_column(sa.ForeignKey('years.id'))
+    day_id: Mapped[int | None] = mapped_column(sa.ForeignKey('days.id'))
+    movable_day_id: Mapped[int | None] = mapped_column(sa.ForeignKey('movable_days.id'))
 
-    holiday_category: Mapped['HolidayCategory'] = relationship(back_populates='holidays')
-    year: Mapped['Year'] = relationship(back_populates='holidays')
-    day: Mapped['Day'] = relationship(back_populates='holidays')
-    movable_day: Mapped['MovableDay'] = relationship(back_populates='holidays')
+    holiday_category: Mapped[HolidayCategory] = relationship(back_populates='holidays')
+    year: Mapped[Year | None] = relationship(back_populates='holidays')
+    day: Mapped[Day | None] = relationship(back_populates='holidays')
+    movable_day: Mapped[MovableDay | None] = relationship(back_populates='holidays')
 
-    saints: Mapped[list['Saint']] = relationship(
+    saints: Mapped[list[Saint]] = relationship(
         secondary='saints_holidays',
         back_populates='holidays',
         viewonly=True
     )
-    saint_associations: Mapped[list['SaintsHolidays']] = relationship(back_populates='holiday')
+    saint_associations: Mapped[list[SaintsHolidays]] = relationship(back_populates='holiday')

--- a/app/models/holiday/holiday_category.py
+++ b/app/models/holiday/holiday_category.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from app import enums
 from app.db.session import Base
+
+if TYPE_CHECKING:
+    from app.models.holiday.holiday import Holiday
 
 
 class HolidayCategory(Base):
@@ -10,4 +17,4 @@ class HolidayCategory(Base):
 
     title: Mapped[enums.HolidayCategoryTitle] = mapped_column(unique=True)
 
-    holidays: Mapped[list['Holiday']] = relationship(back_populates='holiday_category')
+    holidays: Mapped[list[Holiday]] = relationship(back_populates='holiday_category')

--- a/app/models/movable_date/cycle.py
+++ b/app/models/movable_date/cycle.py
@@ -1,8 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import sqlalchemy as sa
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from app import enums
 from app.db.session import Base
+
+if TYPE_CHECKING:
+    from app.models.movable_date.week import Week
 
 
 class Cycle(Base):
@@ -12,4 +19,4 @@ class Cycle(Base):
     num: Mapped[enums.CycleNum] = mapped_column(unique=True)
     title: Mapped[str] = mapped_column(sa.String(30), unique=True)
 
-    weeks: Mapped[list['Week']] = relationship(back_populates='cycle')
+    weeks: Mapped[list[Week]] = relationship(back_populates='cycle')

--- a/app/models/movable_date/divine_service.py
+++ b/app/models/movable_date/divine_service.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from app import enums
 from app.db.session import Base
+
+if TYPE_CHECKING:
+    from app.models.movable_date.movable_date import MovableDate
 
 
 class DivineService(Base):
@@ -10,4 +17,4 @@ class DivineService(Base):
 
     title: Mapped[enums.DivineServiceTitle] = mapped_column(unique=True)
 
-    movable_dates: Mapped[list['MovableDate']] = relationship(back_populates='divine_service')
+    movable_dates: Mapped[list[MovableDate]] = relationship(back_populates='divine_service')

--- a/app/models/movable_date/movable_date.py
+++ b/app/models/movable_date/movable_date.py
@@ -1,17 +1,26 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import sqlalchemy as sa
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from app.db.session import Base
+
+if TYPE_CHECKING:
+    from app.models.movable_date.movable_day import MovableDay
+    from app.models.movable_date.divine_service import DivineService
+    from app.models.reading import Reading
 
 
 class MovableDate(Base):
     __tablename__ = 'movable_dates'
     id: Mapped[int] = mapped_column(primary_key=True)
 
-    movable_day_id = mapped_column(sa.ForeignKey('movable_days.id'))
-    divine_service_id = mapped_column(sa.ForeignKey('divine_services.id'))
+    movable_day_id: Mapped[int] = mapped_column(sa.ForeignKey('movable_days.id'))
+    divine_service_id: Mapped[int] = mapped_column(sa.ForeignKey('divine_services.id'))
 
-    movable_day: Mapped['MovableDay'] = relationship(back_populates='movable_dates')
-    divine_service: Mapped['DivineService'] = relationship(back_populates='movable_dates')
+    movable_day: Mapped[MovableDay] = relationship(back_populates='movable_dates')
+    divine_service: Mapped[DivineService] = relationship(back_populates='movable_dates')
 
-    readings: Mapped[list['Reading']] = relationship(back_populates='movable_date')
+    readings: Mapped[list[Reading]] = relationship(back_populates='movable_date')

--- a/app/models/movable_date/movable_day.py
+++ b/app/models/movable_date/movable_day.py
@@ -1,8 +1,18 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import sqlalchemy as sa
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from app import enums
 from app.db.session import Base
+
+if TYPE_CHECKING:
+    from app.models.movable_date.week import Week
+    from app.models.movable_date.movable_date import MovableDate
+    from app.models.date import Date
+    from app.models.holiday.holiday import Holiday
 
 
 class MovableDay(Base):
@@ -13,11 +23,11 @@ class MovableDay(Base):
     abbr_ru: Mapped[enums.MovableDayAbbrRu]
     title: Mapped[str | None] = mapped_column(sa.String(30), unique=True)
 
-    week_id = mapped_column(sa.ForeignKey('weeks.id'))
+    week_id: Mapped[int] = mapped_column(sa.ForeignKey('weeks.id'))
 
-    week: Mapped['Week'] = relationship(back_populates='movable_days')
+    week: Mapped[Week] = relationship(back_populates='movable_days')
 
-    movable_dates: Mapped[list['MovableDate']] = relationship(back_populates='movable_day')
-    holidays: Mapped[list['Holiday']] = relationship(back_populates='movable_day')
+    days: Mapped[list[Date]] = relationship(back_populates='movable_day')
 
-    days: Mapped[list['Date']] = relationship(back_populates='movable_day')
+    movable_dates: Mapped[list[MovableDate]] = relationship(back_populates='movable_day')
+    holidays: Mapped[list[Holiday]] = relationship(back_populates='movable_day')

--- a/app/models/movable_date/week.py
+++ b/app/models/movable_date/week.py
@@ -1,7 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import sqlalchemy as sa
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from app.db.session import Base
+
+if TYPE_CHECKING:
+    from app.models.movable_date.cycle import Cycle
+    from app.models.movable_date.movable_day import MovableDay
 
 
 class Week(Base):
@@ -13,8 +21,8 @@ class Week(Base):
     sunday_title: Mapped[str | None] = mapped_column(sa.String(50), unique=True)
     sunday_num: Mapped[int] = mapped_column(sa.SmallInteger)
 
-    cycle_id = mapped_column(sa.ForeignKey('cycles.id'))
+    cycle_id: Mapped[int] = mapped_column(sa.ForeignKey('cycles.id'))
 
-    cycle: Mapped['Cycle'] = relationship(back_populates='weeks')
+    cycle: Mapped[Cycle] = relationship(back_populates='weeks')
 
-    movable_days: Mapped[list['MovableDay']] = relationship(back_populates='week')
+    movable_days: Mapped[list[MovableDay]] = relationship(back_populates='week')

--- a/app/models/reading.py
+++ b/app/models/reading.py
@@ -1,15 +1,23 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import sqlalchemy as sa
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from app.db.session import Base
+
+if TYPE_CHECKING:
+    from app.models.movable_date.movable_day import MovableDate
+    from app.models.bible_book.zachalo import Zachalo
 
 
 class Reading(Base):
     __tablename__ = 'readings'
     id: Mapped[int] = mapped_column(primary_key=True)
 
-    movable_date_id = mapped_column(sa.ForeignKey('movable_dates.id'))
-    zachalo_id = mapped_column(sa.ForeignKey('zachalos.id'))
+    movable_date_id: Mapped[int] = mapped_column(sa.ForeignKey('movable_dates.id'))
+    zachalo_id: Mapped[int] = mapped_column(sa.ForeignKey('zachalos.id'))
 
-    movable_date: Mapped['MovableDate'] = relationship(back_populates='readings')
-    zachalo: Mapped['Zachalo'] = relationship(back_populates='readings')
+    movable_date: Mapped[MovableDate] = relationship(back_populates='readings')
+    zachalo: Mapped[Zachalo] = relationship(back_populates='readings')

--- a/app/models/saint/dignity.py
+++ b/app/models/saint/dignity.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from app import enums
 from app.db.session import Base
+
+if TYPE_CHECKING:
+    from app.models.saint.saint import Saint
 
 
 class Dignity(Base):
@@ -10,4 +17,4 @@ class Dignity(Base):
 
     title: Mapped[enums.DignityTitle] = mapped_column(unique=True)
 
-    saints: Mapped[list['Saint']] = relationship(back_populates='dignity')
+    saints: Mapped[list[Saint]] = relationship(back_populates='dignity')

--- a/app/models/saint/face_sanctity.py
+++ b/app/models/saint/face_sanctity.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from app import enums
 from app.db.session import Base
+
+if TYPE_CHECKING:
+    from app.models.saint.saint import Saint
 
 
 class FaceSanctity(Base):
@@ -10,4 +17,4 @@ class FaceSanctity(Base):
 
     title: Mapped[enums.FaceSanctityTitle] = mapped_column(unique=True)
 
-    saints: Mapped[list['Saint']] = relationship(back_populates='face_sanctity')
+    saints: Mapped[list[Saint]] = relationship(back_populates='face_sanctity')

--- a/app/models/saint/saint.py
+++ b/app/models/saint/saint.py
@@ -1,7 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import sqlalchemy as sa
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from app.db.session import Base
+
+if TYPE_CHECKING:
+    from app.models.saint.dignity import Dignity
+    from app.models.saint.face_sanctity import FaceSanctity
+    from app.models.holiday.holiday import Holiday
 
 
 class SaintsHolidays(Base):
@@ -11,7 +20,7 @@ class SaintsHolidays(Base):
     holiday_id: Mapped[int] = mapped_column(sa.ForeignKey('holidays.id'), primary_key=True)
 
     saint: Mapped['Saint'] = relationship(back_populates='holiday_associations')
-    holiday: Mapped['Holiday'] = relationship(back_populates='saint_associations')
+    holiday: Mapped[Holiday] = relationship(back_populates='saint_associations')
 
 
 class Saint(Base):
@@ -21,15 +30,15 @@ class Saint(Base):
     name: Mapped[str | None] = mapped_column(sa.String(100), unique=True)
     slug: Mapped[str] = mapped_column(sa.String(70), unique=True)
 
-    dignity_id = mapped_column(sa.ForeignKey('dignities.id'))
-    face_sanctity_id = mapped_column(sa.ForeignKey('faces_sanctity.id'))
+    dignity_id: Mapped[int | None] = mapped_column(sa.ForeignKey('dignities.id'))
+    face_sanctity_id: Mapped[int | None] = mapped_column(sa.ForeignKey('faces_sanctity.id'))
 
-    dignity: Mapped['Dignity'] = relationship(back_populates='saints')
-    face_sanctity: Mapped['FaceSanctity'] = relationship(back_populates='saints')
+    dignity: Mapped[Dignity | None] = relationship(back_populates='saints')
+    face_sanctity: Mapped[FaceSanctity | None] = relationship(back_populates='saints')
 
-    holidays: Mapped[list['Holiday']] = relationship(
+    holidays: Mapped[list[Holiday]] = relationship(
         secondary='saints_holidays',
         back_populates='saints',
         viewonly=True
     )
-    holiday_associations: Mapped[list['SaintsHolidays']] = relationship(back_populates='saint')
+    holiday_associations: Mapped[list[SaintsHolidays]] = relationship(back_populates='saint')

--- a/app/models/year.py
+++ b/app/models/year.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import sqlalchemy as sa
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from app.db.session import Base
+
+if TYPE_CHECKING:
+    from app.models.holiday.holiday import Holiday
 
 
 class Year(Base):
@@ -11,4 +18,4 @@ class Year(Base):
     title: Mapped[str] = mapped_column(sa.String(30), unique=True)
     _year: Mapped[int] = mapped_column(sa.SmallInteger)
 
-    holidays: Mapped[list['Holiday']] = relationship(back_populates='year')
+    holidays: Mapped[list[Holiday]] = relationship(back_populates='year')

--- a/app/tests/crud/test_week.py
+++ b/app/tests/crud/test_week.py
@@ -16,21 +16,20 @@ def test_create_week(db: Session) -> None:
     assert week.cycle_id == cycle.id
 
 
-def test_create_week_bas_cycle_id_is_none(db: Session) -> None:
+def test_create_week_cycle_id_is_none_bad(db: Session) -> None:
     """
     ЭТОТ ТЕСТ РАБОТАТЕ, НО САМА ЛОГИКА ПРИЛОЖЕНИЯ НЕПРАВИЛЬНО (я так думаю)
     Т.К МЫ НЕ ДОЛЖНЫ ИМЕТЬ ВОЗМОЖНОСТЬ СОЗДАВАТЬ Week БЕЗ cycle_id
     ТО ЕСТЬ СВЯЗТЬ Cycle -> Week должно всегда быть, сразу при создании модели Week
     """
-    cycle = create_random_cycle(db)
     week_in = create_random_week_in()
-    week = crud.create_week(db, cycle_id=None, week=week_in)
-    assert week.title == week_in.title
-    assert week.sunday_title == week_in.sunday_title
-    assert week.cycle_id is None
+    with pytest.raises(IntegrityError) as e:
+        week = crud.create_week(db, cycle_id=None, week=week_in)
+    assert e.type is IntegrityError
+    assert e.value.args[0] == '(sqlite3.IntegrityError) NOT NULL constraint failed: weeks.cycle_id'
 
 
-def test_create_week_bad_unique(db: Session) -> None:
+def test_create_week_unique_bad(db: Session) -> None:
     cycle = create_random_cycle(db)
     week_in = create_random_week_in()
     week_in.title = 'foo'


### PR DESCRIPTION
…ationship и ForeignKey

Там где возможное None у связи указывать:
- Mapped[int | None]
- Mapped[model | None] Там где точно должна быть связь всегда указывать:
- Mapped[int]
- Mapped[model] И будет ошибка при попытке создать модель с None значением связи. Аннотации делала по примеру, как в ссылке - блок/указание 'Tip': https://docs.sqlalchemy.org/en/20/orm/basic_relationships.html#nullable-many-to-one

Добавить в каждый файл models:
from __future__ import annotations # для того, чтобы писать модель не в кавычках: 'model'

from typing import TYPE_CHECKING # чтобы не было ошибок cycle import

if TYPE_CHECKING:
    *импорты других моделей для связи в Mapped[] (relationship)

Так же в sqlalchemy 2 не нужно писать в relationship(..., uselist=False) для связи One To One. Теперь relationship может взять информацию об этом из Mapped annotation.
> Новое в версии 2.0: конструкция relationship() может получить действующее значение relationship.uselist параметра из заданной Mapped аннотации.
Подробнее: https://docs.sqlalchemy.org/en/20/orm/basic_relationships.html#one-to-one

fix(test/crud): поправил один тест test_create_week_cycle_id_is_none_bad т.к теперь он перестал работать. И это хорошо. Так как он работал с неправильной логикой (в комментариях к нему это написано). А теперь когда добавились аннотации и в полях foo_id (ForeignKey) в Mapped[int] указывается что связь NOT NULL. Или быть связь None тогда: Mapped[int | None]
И соответственно если попытаться создать модель указав None в поле, которое Mapped[int] (NOT NULL) будет ошибка - что в тесте и теперь проверяется.